### PR TITLE
Format all code & add automated code formatting for files about to be committed

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    telegram: ""
-}
+  telegram: ""
+};

--- a/main.js
+++ b/main.js
@@ -1,70 +1,70 @@
-const keys = require('./config');
-const bb = require('bot-brother');
-const axios = require('axios');
-const interval = require('interval-promise')
+const keys = require("./config");
+const bb = require("bot-brother");
+const axios = require("axios");
+const interval = require("interval-promise");
 
 // Create bot object
 bot = bb({
-    key: keys.telegram,
-    sessionManager: bb.sessionManager.memory(),
-    polling: { interval: 0, timeout: 1 }
+  key: keys.telegram,
+  sessionManager: bb.sessionManager.memory(),
+  polling: { interval: 0, timeout: 1 }
 });
 
 // List of supported currencies throughout the app
-supportedCurrencies = ['USD', 'EUR', 'GBP'];
-supportedCryptos = ['BTC', 'ETH', 'BCH'];
+supportedCurrencies = ["USD", "EUR", "GBP"];
+supportedCryptos = ["BTC", "ETH", "BCH"];
 supportedAll = supportedCurrencies.concat(supportedCryptos);
 
 // Build API url
-apiUrl =    'https://min-api.cryptocompare.com/data/pricemulti?fsyms=' + 
-            supportedAll.join(',') +
-            '&tsyms=' +
-            supportedAll.join(',');
+apiUrl =
+  "https://min-api.cryptocompare.com/data/pricemulti?fsyms=" +
+  supportedAll.join(",") +
+  "&tsyms=" +
+  supportedAll.join(",");
 
 // Default message options
-messageOptions = {parse_mode: 'Markdown', disable_notification: true, reply_markup: {}};
+messageOptions = {
+  parse_mode: "Markdown",
+  disable_notification: true,
+  reply_markup: {}
+};
 
 // Check notifications every 3 seconds
 // TODO: Change to greater interval, load notifications from file?
 notifications = {};
 
 interval(async () => {
-    await checkNotifications()
-}, 1000 * 3)
-
+  await checkNotifications();
+}, 1000 * 3);
 
 /*
 * Returns help text
 **/
 function getHelpText(command) {
-    if (command == 'help') {
-        return  '*Commands*' + 
-                '```\n/help [command]\n' + 
-                '/crypto\n' +
-                '/notify```';
-    }
+  if (command == "help") {
+    return "*Commands*" + "```\n/help [command]\n" + "/crypto\n" + "/notify```";
+  }
 
-    if (command === 'crypto') {
-        return  '*Usage:*\n' +
-                '/crypto <amount> <from> to <to>\n' +
-                '/crypto'
+  if (command === "crypto") {
+    return "*Usage:*\n" + "/crypto <amount> <from> to <to>\n" + "/crypto";
+  }
 
-    }
+  if (command === "notify") {
+    return (
+      "*Usage:*\n" +
+      "/notify <comparator><amount> <currency>\n" +
+      "/notify clear\n" +
+      "/notify\n\n" +
+      "*Example:* /notify btc >150 eur\n\n" +
+      getNotifications()
+    );
+  }
 
-    if (command === 'notify') {
-        return  '*Usage:*\n' + 
-                '/notify <comparator><amount> <currency>\n' +
-                '/notify clear\n' + 
-                '/notify\n\n' +
-                '*Example:* /notify btc >150 eur\n\n' +
-                getNotifications();
-    }
-
-    return false;
+  return false;
 }
 
 function isNumber(num) {
-    return !isNaN(num);
+  return !isNaN(num);
 }
 
 /*
@@ -77,139 +77,143 @@ function isNumber(num) {
 }); */
 
 // Show help
-bot.command('help')
-.invoke(function (ctx) {
-    const args = ctx.command.args;
+bot.command("help").invoke(function(ctx) {
+  const args = ctx.command.args;
 
-    if (args.length === 0) {
-        ctx.sendMessage(getHelpText('help'), messageOptions);
-    }
-    if (args.length == 1) {
-        const text = getHelpText(args[0]);
+  if (args.length === 0) {
+    ctx.sendMessage(getHelpText("help"), messageOptions);
+  }
+  if (args.length == 1) {
+    const text = getHelpText(args[0]);
 
-        if (text) {
-            ctx.sendMessage(text, messageOptions);
-        } else {
-            ctx.sendMessage('`Command not found`', messageOptions);
-        }
+    if (text) {
+      ctx.sendMessage(text, messageOptions);
+    } else {
+      ctx.sendMessage("`Command not found`", messageOptions);
     }
+  }
 });
 
 /*
 * Crypto command
 */
-bot.command('crypto')
-.invoke(function (ctx) {
-    axios.get(apiUrl)
-    .then(function (response) {
-        const args = ctx.command.args;
-        const data = response.data;
-        
-        // No arguments
-        if (args.length === 0) {
-            let result = '';
+bot.command("crypto").invoke(function(ctx) {
+  axios
+    .get(apiUrl)
+    .then(function(response) {
+      const args = ctx.command.args;
+      const data = response.data;
 
-            supportedCryptos.forEach(crypto => {
-                const usd = (data[crypto]['USD']);
-                const eur = (data[crypto]['EUR']);
+      // No arguments
+      if (args.length === 0) {
+        let result = "";
 
-                result += `*1 ${crypto}* to *USD*: \`${usd}\`\n`
-                result += `*1 ${crypto}* to *EUR*: \`${eur}\``
+        supportedCryptos.forEach(crypto => {
+          const usd = data[crypto]["USD"];
+          const eur = data[crypto]["EUR"];
 
-                result += '\n\n';
-            });
+          result += `*1 ${crypto}* to *USD*: \`${usd}\`\n`;
+          result += `*1 ${crypto}* to *EUR*: \`${eur}\``;
 
-            result.slice(0, -2);
-            result += '';
+          result += "\n\n";
+        });
 
-            ctx.sendMessage(result, messageOptions);
+        result.slice(0, -2);
+        result += "";
+
+        ctx.sendMessage(result, messageOptions);
+      }
+
+      // Example: 1 btc to eur
+      if (args.length === 4) {
+        if (
+          isNumber(args[0]) &&
+          supportedAll.includes(args[1].toUpperCase()) &&
+          args[2] === "to" &&
+          supportedAll.includes(args[3].toUpperCase())
+        ) {
+          const fromAmount = args[0];
+          const fromCurrency = args[1].toUpperCase();
+          const toCurrency = args[3].toUpperCase();
+
+          let result =
+            `*${fromAmount} ${fromCurrency}* to *${toCurrency}*: ` +
+            `\`${fromAmount * data[fromCurrency][toCurrency]}\``;
+
+          ctx.sendMessage(result, messageOptions);
+        } else {
+          // TODO: Show help for this command
         }
-
-        // Example: 1 btc to eur
-        if (args.length === 4) {
-            if (isNumber(args[0]) && supportedAll.includes(args[1].toUpperCase()) &&
-                args[2] === "to"  && supportedAll.includes(args[3].toUpperCase())) {
-                
-                const fromAmount = args[0];
-                const fromCurrency = args[1].toUpperCase();
-                const toCurrency = args[3].toUpperCase();
-
-                let result = `*${fromAmount} ${fromCurrency}* to *${toCurrency}*: ` +
-                             `\`${fromAmount * data[fromCurrency][toCurrency]}\``;
-
-                ctx.sendMessage(result, messageOptions);
-            } else {
-              // TODO: Show help for this command  
-            }
-        }
+      }
     })
-    .catch(function (error) {
-        console.log(error);
+    .catch(function(error) {
+      console.log(error);
     });
 });
 
 /*
 * Notify command
 */
-bot.command('notify')
-.invoke(function (ctx) {
-    axios.get(apiUrl)
-    .then(function (response) {
-        const args = ctx.command.args;
+bot.command("notify").invoke(function(ctx) {
+  axios
+    .get(apiUrl)
+    .then(function(response) {
+      const args = ctx.command.args;
 
-        // Show list of current notifications
-        if (args.length == 0) {
-            ctx.sendMessage(getNotifications(), messageOptions);
-            
-        } else if (args.length == 1) {
-            if (args[0] == 'clear') {
-                notifications = [];
-                ctx.sendMessage("Cleared notifying list!", messageOptions);
-            } else {
-                ctx.sendMessage(getHelpText('notify'), messageOptions);
-            }
+      // Show list of current notifications
+      if (args.length == 0) {
+        ctx.sendMessage(getNotifications(), messageOptions);
+      } else if (args.length == 1) {
+        if (args[0] == "clear") {
+          notifications = [];
+          ctx.sendMessage("Cleared notifying list!", messageOptions);
+        } else {
+          ctx.sendMessage(getHelpText("notify"), messageOptions);
+        }
 
         // Example: /notify btc >15000 eur
-        } else if(args.length == 3) {
-            const crypto = args[0].toUpperCase();
-            const comparator = args[1][0];
-            const rate = args[1].slice(1); // Slice removes < or > if there's any
-            const currency = args[2].toUpperCase();
+      } else if (args.length == 3) {
+        const crypto = args[0].toUpperCase();
+        const comparator = args[1][0];
+        const rate = args[1].slice(1); // Slice removes < or > if there's any
+        const currency = args[2].toUpperCase();
 
-            // Add new notification if values are valid
-            if( ['>', '<'].includes(comparator) &&
-                supportedCryptos.includes(crypto) &&
-                supportedCurrencies.includes(currency) &&
-                isNumber(rate)) {
-                
-                const chatId = ctx.message.chat.id;
-                let notification = [];
+        // Add new notification if values are valid
+        if (
+          [">", "<"].includes(comparator) &&
+          supportedCryptos.includes(crypto) &&
+          supportedCurrencies.includes(currency) &&
+          isNumber(rate)
+        ) {
+          const chatId = ctx.message.chat.id;
+          let notification = [];
 
-                notification.crypto     = crypto;
-                notification.comparator = comparator;
-                notification.rate       = parseFloat(rate);
-                notification.currency   = currency;
-                notification.ctx        = ctx;
+          notification.crypto = crypto;
+          notification.comparator = comparator;
+          notification.rate = parseFloat(rate);
+          notification.currency = currency;
+          notification.ctx = ctx;
 
-                // Create chat "group" if it doesn't exist
-                if (notifications[chatId] === undefined) {
-                    notifications[chatId] = [];
-                }
+          // Create chat "group" if it doesn't exist
+          if (notifications[chatId] === undefined) {
+            notifications[chatId] = [];
+          }
 
-                notifications[chatId].push(notification);
+          notifications[chatId].push(notification);
 
-                ctx.sendMessage('Added new notification!\n\n' +
-                                getNotifications(chatId), messageOptions);
-            } else {
-                ctx.sendMessage(getHelpText('notify'), messageOptions);
-            }
-
+          ctx.sendMessage(
+            "Added new notification!\n\n" + getNotifications(chatId),
+            messageOptions
+          );
         } else {
-            ctx.sendMessage(getHelpText("notify"), messageOptions);
+          ctx.sendMessage(getHelpText("notify"), messageOptions);
         }
+      } else {
+        ctx.sendMessage(getHelpText("notify"), messageOptions);
+      }
     })
-    .catch(function (error) {
-        console.log(error);
+    .catch(function(error) {
+      console.log(error);
     });
 });
 
@@ -217,82 +221,86 @@ bot.command('notify')
 * Check notifications
 */
 function checkNotifications() {
-    if (Object.keys(notifications).length > 0) {
-        return axios.get(apiUrl)
-        .then(function (response) {
-            const data = response.data;
+  if (Object.keys(notifications).length > 0) {
+    return axios
+      .get(apiUrl)
+      .then(function(response) {
+        const data = response.data;
 
-            // Loop through each chat
-            for (let chatId in notifications) {
+        // Loop through each chat
+        for (let chatId in notifications) {
+          // Loop through each notification
+          notifications[chatId].forEach((notification, index, object) => {
+            // Get current rate of crypto
+            const currentRate = data[notification.crypto][
+              notification.currency
+            ].toFixed(2);
 
-                // Loop through each notification
-                notifications[chatId].forEach((notification, index, object) => {
-
-                    // Get current rate of crypto
-                    const currentRate = data[notification.crypto][notification.currency].toFixed(2);
-
-                    // Check if current rate is over / under the notification rate
-                    if (notification.comparator === '>') {
-                        if (notification.rate < currentRate) {
-                            // Show notification and remove it
-                            showNotification(notification, currentRate);
-                            object.splice(index, 1);
-                        }
-                    }
-                    
-                    else if (notification.comparator === '<') {
-                        if (notification.rate > currentRate) {
-                            // Show notification and remove it
-                            showNotification(notification, currentRate);
-                            object.splice(index, 1);
-                        }
-                    }
-                });
+            // Check if current rate is over / under the notification rate
+            if (notification.comparator === ">") {
+              if (notification.rate < currentRate) {
+                // Show notification and remove it
+                showNotification(notification, currentRate);
+                object.splice(index, 1);
+              }
+            } else if (notification.comparator === "<") {
+              if (notification.rate > currentRate) {
+                // Show notification and remove it
+                showNotification(notification, currentRate);
+                object.splice(index, 1);
+              }
             }
-        })
-        .catch(function (error) {
-            console.log(error);
-        });
-    }
-    return Promise.resolve();
+          });
+        }
+      })
+      .catch(function(error) {
+        console.log(error);
+      });
+  }
+  return Promise.resolve();
 }
 
 /*
 * Send notification message
 */
 function showNotification(notification, currentRate) {
-    const overOrUnder = (notification.comparator === ">") ? "over" : "under";
+  const overOrUnder = notification.comparator === ">" ? "over" : "under";
 
-    notification.ctx.sendMessage(
-        `*1 ${notification.crypto}* is now ${overOrUnder} *${notification.rate} ${notification.currency}*\n\n` + 
-        `*1 ${notification.crypto}:* ${currentRate} ${notification.currency}`,
-        messageOptions
-    );
+  notification.ctx.sendMessage(
+    `*1 ${notification.crypto}* is now ${overOrUnder} *${notification.rate} ${
+      notification.currency
+    }*\n\n` +
+      `*1 ${notification.crypto}:* ${currentRate} ${notification.currency}`,
+    messageOptions
+  );
 }
 
 /*
 * Returns a string containing all current notifications
 */
 function getNotifications(chatId) {
-    let currentlyNotifying = '*Currently notifying when:*\n';
+  let currentlyNotifying = "*Currently notifying when:*\n";
 
-    // No notifications for current chat
-    if (notifications[chatId] === undefined) {
-        currentlyNotifying += 'Never';
-    
+  // No notifications for current chat
+  if (notifications[chatId] === undefined) {
+    currentlyNotifying += "Never";
+
     // Chat has notifications
-    } else if (notifications[chatId].length > 0) {
-        notifications[chatId].forEach(notification => {
+  } else if (notifications[chatId].length > 0) {
+    notifications[chatId].forEach(notification => {
+      currentlyNotifying +=
+        notification.crypto +
+        " " +
+        notification.comparator +
+        notification.rate +
+        " " +
+        notification.currency +
+        "\n";
+    });
 
-            currentlyNotifying +=   notification.crypto + " " +
-                                    notification.comparator + notification.rate + " " +
-                                    notification.currency + "\n";
+    // Remove trailing \n
+    currentlyNotifying.slice(0, -1);
+  }
 
-        });
-
-        // Remove trailing \n
-        currentlyNotifying.slice(0, -1); 
-    }
-
-    return currentlyNotifying;
+  return currentlyNotifying;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,56 @@
         "json-schema-traverse": "0.3.1"
       }
     },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved":
+        "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved":
+        "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+      "dev": true
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved":
+        "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved":
+            "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
+      }
     },
     "asn1": {
       "version": "0.1.11",
@@ -32,7 +73,8 @@
     },
     "assert-plus": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+      "resolved":
+        "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
       "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
     },
     "async": {
@@ -66,12 +108,14 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
@@ -101,7 +145,8 @@
     },
     "bot-brother": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/bot-brother/-/bot-brother-2.1.5.tgz",
+      "resolved":
+        "https://registry.npmjs.org/bot-brother/-/bot-brother-2.1.5.tgz",
       "integrity": "sha1-g/cW2X1FaxEDrDdZmd45u9l2iGg=",
       "requires": {
         "bluebird": "2.11.0",
@@ -127,7 +172,8 @@
     },
     "brace-expansion": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "resolved":
+        "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
         "balanced-match": "1.0.0",
@@ -151,14 +197,75 @@
         "supports-color": "2.0.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity":
+        "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved":
+        "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved":
+        "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved":
+        "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved":
+        "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved":
+        "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity":
+        "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved":
+        "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "resolved":
+        "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
         "delayed-stream": "1.0.0"
@@ -167,17 +274,46 @@
     "commander": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+      "integrity":
+        "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved":
+        "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved":
+        "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity":
+        "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved":
+        "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
@@ -202,28 +338,46 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity":
+        "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity":
+        "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "dot-object": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/dot-object/-/dot-object-1.7.0.tgz",
-      "integrity": "sha512-X91KaxzQmhQvfokXCdM8EkJVDHe5HlffhT4eaS6CsLk8Nhs9ChA6KWmrt8kgCz5rmLKzoOEP2tmRK/kBvomFwg==",
+      "resolved":
+        "https://registry.npmjs.org/dot-object/-/dot-object-1.7.0.tgz",
+      "integrity":
+        "sha512-X91KaxzQmhQvfokXCdM8EkJVDHe5HlffhT4eaS6CsLk8Nhs9ChA6KWmrt8kgCz5rmLKzoOEP2tmRK/kBvomFwg==",
       "requires": {
         "commander": "2.12.2",
         "glob": "7.1.2"
@@ -231,7 +385,8 @@
     },
     "double-ended-queue": {
       "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "ecc-jsbn": {
@@ -248,23 +403,70 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved":
+        "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "requires": {
         "once": "1.4.0"
       }
     },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved":
+        "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity":
+        "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
     },
     "eventemitter3": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
       "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+    },
+    "execa": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
     },
     "extend": {
       "version": "3.0.1",
@@ -273,28 +475,50 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-type": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved":
+        "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
-      "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
+      "resolved":
+        "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
+      "integrity":
+        "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
       "requires": {
         "debug": "3.1.0"
       },
@@ -302,7 +526,8 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity":
+            "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -311,7 +536,8 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
@@ -326,7 +552,8 @@
       "dependencies": {
         "combined-stream": {
           "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "resolved":
+            "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
           "requires": {
             "delayed-stream": "0.0.5"
@@ -334,28 +561,47 @@
         },
         "delayed-stream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "resolved":
+            "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
           "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
         }
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "generate-function": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
         "is-property": "1.0.2"
       }
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved":
+        "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity":
+        "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved":
+        "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -367,7 +613,8 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
@@ -375,7 +622,8 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity":
+        "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -387,12 +635,14 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
       "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
       "requires": {
         "bluebird": "2.11.0",
@@ -408,6 +658,12 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "hawk": {
       "version": "2.3.1",
@@ -427,12 +683,35 @@
     },
     "http-signature": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
       "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
       "requires": {
         "asn1": "0.1.11",
         "assert-plus": "0.1.5",
         "ctype": "0.5.3"
+      }
+    },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity":
+        "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      }
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved":
+        "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
       }
     },
     "inflight": {
@@ -451,18 +730,81 @@
     },
     "interval-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interval-promise/-/interval-promise-1.1.0.tgz",
-      "integrity": "sha512-Wq2ESx8S0UrfZPzu0/t1d7VMzLOoqT/mUL+cvhDjnq2xFhtokUSlVYKp7Q7B5dZliNr5GNl53s0roNI1aIk2aA=="
+      "resolved":
+        "https://registry.npmjs.org/interval-promise/-/interval-promise-1.1.0.tgz",
+      "integrity":
+        "sha512-Wq2ESx8S0UrfZPzu0/t1d7VMzLOoqT/mUL+cvhDjnq2xFhtokUSlVYKp7Q7B5dZliNr5GNl53s0roNI1aIk2aA=="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved":
+        "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity":
+        "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved":
+        "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved":
+        "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved":
+        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
     },
     "is-my-json-valid": {
       "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "resolved":
+        "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity":
+        "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
@@ -470,14 +812,51 @@
         "xtend": "4.0.1"
       }
     },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved":
+        "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved":
+        "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "resolved":
+        "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
@@ -485,10 +864,84 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved":
+        "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity":
+        "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved":
+        "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity":
+        "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved":
+            "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity":
+            "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity":
+            "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved":
+            "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity":
+        "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -498,22 +951,26 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved":
+        "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
@@ -529,9 +986,190 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
+      }
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved":
+        "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity":
+        "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved":
+            "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity":
+            "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity":
+            "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity":
+            "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved":
+            "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.6",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved":
+            "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved":
+        "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved":
+        "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved":
+            "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved":
+            "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved":
+        "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
       }
     },
     "lodash": {
@@ -541,13 +1179,83 @@
     },
     "lodash.toarray": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+    },
+    "log-symbols": {
+      "version": "2.1.0",
+      "resolved":
+        "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+      "integrity":
+        "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved":
+            "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity":
+            "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity":
+            "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved":
+            "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved":
+        "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity":
+        "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity":
+        "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.12.0",
@@ -556,7 +1264,8 @@
     },
     "mime-types": {
       "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+      "resolved":
+        "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
       "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
       "requires": {
         "mime-db": "1.12.0"
@@ -565,7 +1274,8 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity":
+        "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -590,15 +1300,18 @@
     },
     "node-emoji": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+      "resolved":
+        "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity":
+        "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
       "requires": {
         "lodash.toarray": "4.4.0"
       }
     },
     "node-telegram-bot-api": {
       "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/node-telegram-bot-api/-/node-telegram-bot-api-0.23.3.tgz",
+      "resolved":
+        "https://registry.npmjs.org/node-telegram-bot-api/-/node-telegram-bot-api-0.23.3.tgz",
       "integrity": "sha1-Z3zoBtFM85uIyiVdZObyXgAx3r8=",
       "requires": {
         "bl": "1.2.1",
@@ -614,12 +1327,14 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "bl": {
@@ -632,8 +1347,10 @@
         },
         "bluebird": {
           "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+          "resolved":
+            "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity":
+            "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
         "boom": {
           "version": "4.3.1",
@@ -645,12 +1362,14 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "cryptiles": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "resolved":
+            "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "requires": {
             "boom": "5.2.0"
@@ -659,7 +1378,8 @@
             "boom": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "integrity":
+                "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "requires": {
                 "hoek": "4.2.0"
               }
@@ -668,7 +1388,8 @@
         },
         "form-data": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "resolved":
+            "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "requires": {
             "asynckit": "0.4.0",
@@ -678,7 +1399,8 @@
         },
         "har-validator": {
           "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "resolved":
+            "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "requires": {
             "ajv": "5.5.2",
@@ -688,7 +1410,8 @@
         "hawk": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "integrity":
+            "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "requires": {
             "boom": "4.3.1",
             "cryptiles": "3.1.2",
@@ -699,11 +1422,13 @@
         "hoek": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+          "integrity":
+            "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
         },
         "http-signature": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "requires": {
             "assert-plus": "1.0.0",
@@ -723,7 +1448,8 @@
         },
         "mime-types": {
           "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "resolved":
+            "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "requires": {
             "mime-db": "1.30.0"
@@ -732,12 +1458,15 @@
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+          "integrity":
+            "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
         },
         "readable-stream": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "resolved":
+            "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity":
+            "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -751,7 +1480,8 @@
         "request": {
           "version": "2.83.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "integrity":
+            "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "requires": {
             "aws-sign2": "0.7.0",
             "aws4": "1.6.0",
@@ -780,22 +1510,26 @@
         "sntp": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "integrity":
+            "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "requires": {
             "hoek": "4.2.0"
           }
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "resolved":
+            "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity":
+            "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "requires": {
             "safe-buffer": "5.1.1"
@@ -804,7 +1538,8 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+          "integrity":
+            "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         }
       }
     },
@@ -813,10 +1548,62 @@
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
+    "normalize-path": {
+      "version": "1.0.0",
+      "resolved":
+        "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+      "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+      "dev": true
+    },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.3.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved":
+        "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "2.0.1"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.3.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved":
+        "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "resolved":
+        "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved":
+        "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -826,25 +1613,134 @@
         "wrappy": "1.0.2"
       }
     },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity":
+        "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "3.0.0",
+      "resolved":
+        "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+      "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved":
+        "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity":
+        "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved":
+        "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity":
+        "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved":
+            "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved":
+            "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity":
+            "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "resolved":
+        "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "pump": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "integrity":
+        "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
         "end-of-stream": "1.4.0",
         "once": "1.4.0"
@@ -862,7 +1758,8 @@
     },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "resolved":
+        "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
         "core-util-is": "1.0.2",
@@ -874,7 +1771,8 @@
     "redis": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "integrity":
+        "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "requires": {
         "double-ended-queue": "2.1.0-0",
         "redis-commands": "1.3.1",
@@ -883,13 +1781,24 @@
     },
     "redis-commands": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
       "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
     },
     "redis-parser": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
       "version": "2.57.0",
@@ -918,7 +1827,8 @@
     },
     "request-promise": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-2.0.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/request-promise/-/request-promise-2.0.1.tgz",
       "integrity": "sha1-rL1HtyXjk3Lt4xdM8pw42ezysw0=",
       "requires": {
         "bluebird": "2.11.0",
@@ -933,10 +1843,80 @@
         }
       }
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved":
+        "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved":
+        "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity":
+        "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved":
+            "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "resolved":
+        "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity":
+        "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved":
+        "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved":
+        "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved":
+        "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved":
+        "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
     },
     "sntp": {
       "version": "1.0.9",
@@ -948,7 +1928,8 @@
     },
     "sprintf-js": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
       "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
     },
     "sshpk": {
@@ -973,37 +1954,105 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved":
+        "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved":
+        "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved":
+        "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved":
+        "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved":
+        "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity":
+        "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "resolved":
+        "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved":
+        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "2.1.1"
       }
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved":
+        "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
+    },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved":
+        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved":
+        "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
     },
     "tough-cookie": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "resolved":
+        "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
         "punycode": "1.4.1"
@@ -1011,7 +2060,8 @@
     },
     "tunnel-agent": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "resolved":
+        "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
     },
     "tweetnacl": {
@@ -1022,7 +2072,8 @@
     },
     "underscore.string": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "resolved":
+        "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "requires": {
         "sprintf-js": "1.1.1",
@@ -1031,7 +2082,8 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved":
+        "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "verror": {
@@ -1046,9 +2098,20 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved":
+            "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity":
+        "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
       }
     },
     "wrappy": {
@@ -1060,6 +2123,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,16 @@
     "interval-promise": "^1.1.0"
   },
   "devDependencies": {
-    "interval-promise": "^1.1.0"
+    "husky": "^0.14.3",
+    "interval-promise": "^1.1.0",
+    "lint-staged": "^6.0.0",
+    "prettier": "^1.9.2"
+  },
+  "lint-staged": {
+    "*.{js,json,css,md}": ["prettier --write", "git add"]
   },
   "scripts": {
+    "precommit": "lint-staged",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": ""
   },


### PR DESCRIPTION
Asentakaa tää VSCodeen:

![image](https://user-images.githubusercontent.com/1206987/34323185-2580afda-e835-11e7-9b6d-407d47c81c33.png)

Sen jälkeen formatoi koodin aina automaattisesti kun tallennatte tiedoston. Tekee saman myös tiedoille, jotka on menossa committiin. Tällee säästytään siltä, että joku jolla ei oo Prettier VSCode plugaria ei pysty commitoimaan formatoimatonta koodia

Formatoin nyt tässä jo tuon `main.js` filun 